### PR TITLE
Slash table name fix

### DIFF
--- a/lib/quick_count.rb
+++ b/lib/quick_count.rb
@@ -35,7 +35,7 @@ private
           EXECUTE 'SELECT
             CASE
             WHEN SUM(estimate)::integer < '|| threshold ||' THEN
-              (SELECT COUNT(*) FROM '|| table_name ||')
+              (SELECT COUNT(*) FROM "'|| table_name ||'")
             ELSE
               SUM(estimate)::integer
             END AS count


### PR DESCRIPTION
* Allow for PG table names with slashes by wrapping interpolated table name with double quotes